### PR TITLE
rails-g-model-Article , rails db:migrate , article.rb修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,4 @@
+class Article < ApplicationRecord
+  validates :title , presence: true
+  validates :content , presence: true
+end

--- a/db/migrate/20240731032028_create_articles.rb
+++ b/db/migrate/20240731032028_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_29_050853) do
+ActiveRecord::Schema.define(version: 2024_07_31_032028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "sample_articles", force: :cascade do |t|
     t.string "title"


### PR DESCRIPTION
#概要
- rails g model Article で title と content カラムを含む model を作成
- rails db:migrate で DB に反映
- article.rb に validates を追記